### PR TITLE
pass invoke params to resolve

### DIFF
--- a/classes/Container.php
+++ b/classes/Container.php
@@ -152,7 +152,7 @@ class Container implements ContainerInterface
 				$object = $class;
 				$class = get_class($object);
 			} else {
-				$object = $this->resolve($class);
+				$object = $this->resolve($class, $params);
 			}
 
 			$reflFunc = new ReflectionMethod($object, $method);


### PR DESCRIPTION
Not sure if this is safe or desirable. If someone has this code:

``` php
class C {
    public function __construct($v) {}
    public function f($v) {}
}
```

`Container->invoke(['C', 'f'], ['$v' => 'whatever'])` is going to have some weird behaviour.
